### PR TITLE
Use files in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0-beta.1",
   "description": "Create a custom Modernizr build during webpack compile",
   "main": "index.js",
+  "files": [
+    "index.js"
+  ],
   "scripts": {
     "test": "node karma.runner.js"
   },


### PR DESCRIPTION
Avoids loads of unnecessary files.

From what I could understand, the `client` directory contains only tests?

Before:
```
    6222 modernizr-webpack-plugin-1.0.0-beta.1.tgz
-rw-r--r--  0 501    20       1147 Oct 13 23:12 package/package.json
-rw-r--r--  0 501    20        187 Oct 13 23:12 package/.npmignore
-rw-r--r--  0 501    20       1511 Oct 13 23:12 package/README.md
-rw-r--r--  0 501    20       1088 Oct 13 23:12 package/LICENSE
-rw-r--r--  0 501    20       1049 Oct 13 23:12 package/karma.runner.js
-rw-r--r--  0 501    20        170 Oct 13 23:12 package/karma.entry.js
-rw-r--r--  0 501    20       1032 Oct 13 23:12 package/karma.conf.js
-rw-r--r--  0 501    20       2976 Oct 13 23:17 package/index.js
-rw-r--r--  0 501    20        397 Oct 13 23:12 package/webpack.config.js
-rw-r--r--  0 501    20        516 Oct 13 23:12 package/client/entry.js
-rw-r--r--  0 501    20        383 Oct 13 23:12 package/client/entry.spec.js
-rw-r--r--  0 501    20         52 Oct 13 23:12 package/client/feature-detects.js
-rw-r--r--  0 501    20        777 Oct 13 23:12 package/.editorconfig
-rw-r--r--  0 501    20        107 Oct 13 23:12 package/.travis.yml
-rw-r--r--  0 501    20       4334 Oct 13 23:12 package/.eslintrc
-rw-r--r--  0 501    20         16 Oct 13 23:12 package/.babelrc
```

After:
```
    2820 modernizr-webpack-plugin-1.0.0-beta.1.tgz
-rw-r--r--  0 501    20       1180 Oct 13 23:18 package/package.json
-rw-r--r--  0 501    20       1511 Oct 13 23:12 package/README.md
-rw-r--r--  0 501    20       1088 Oct 13 23:12 package/LICENSE
-rw-r--r--  0 501    20       2976 Oct 13 23:17 package/index.js
```