### PR TITLE
Wrap html-webpack-plugin in a try-catch

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,12 @@
 /* eslint-disable no-process-env */
 var CachedSource = require('webpack-core/lib/CachedSource');
 var ConcatSource = require('webpack-core/lib/ConcatSource');
-var HtmlWebpackPlugin = require('html-webpack-plugin');
+var HtmlWebpackPlugin;
+
+try {
+  HtmlWebpackPlugin = require('html-webpack-plugin');
+} catch(ignored){
+}
 
 var path = require('path');
 var url = require('url');
@@ -27,7 +32,7 @@ function ModernizrPlugin(options) {
 
   this.options = assign({}, {
     filename: 'modernizr-bundle.js',
-    htmlWebPackPluginIntegration: true,
+    htmlWebPackPluginIntegration: !!HtmlWebpackPlugin,
     minify: process.env.NODE_ENV === 'production',
     noChunk: false
   }, options);


### PR DESCRIPTION
If html-webpack-plugin is NOT used in a project, you get Module not found

This PR is made from GH's GUI, so formatting might be off.

GH also makes it hard to change multiple files in the same PR... The readme should be updated

> Option to include support for html-webpack-plugin. Defaults to true. Note: Only applies if the plugin in found in the webpack config plugin array

With something like "defaults to true if `webpack-html-plugin` is found in the project's modules"