### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,9 +136,9 @@ var modernizrPluginConfig = {
 _template.html_
 ```html
 <!-- example of template without noChunk-->
-<script src="{%= o.htmlWebpackPlugin.files.chunks['mybundle'].entry %}"></script>
+<script src="<%= o.htmlWebpackPlugin.files.chunks['mybundle'].entry %>"></script>
 
 <!-- example of template WITH noChunk-->
-<script src="{%= o.htmlWebpackPlugin.files.mybundle %}"></script>
+<script src="<%= o.htmlWebpackPlugin.files.mybundle %>"></script>
 
 ```

--- a/README.md
+++ b/README.md
@@ -136,9 +136,9 @@ var modernizrPluginConfig = {
 _template.html_
 ```html
 <!-- example of template without noChunk-->
-<script src="<%= o.htmlWebpackPlugin.files.chunks['mybundle'].entry %>"></script>
+<script src="<%= htmlWebpackPlugin.files.chunks['mybundle'].entry %>"></script>
 
 <!-- example of template WITH noChunk-->
-<script src="<%= o.htmlWebpackPlugin.files.mybundle %>"></script>
+<script src="<%= htmlWebpackPlugin.files.mybundle %>"></script>
 
 ```


### PR DESCRIPTION
htmlWebpackPlugin now uses `<%` over `{%` for template strings.

Taken from htmlWebpackPlugin docs:
> Templates for the html-webpack-plugin are implemented using underscore templates (previously, in 2.x, blueimp templates). You can write your own as well.