### PR TITLE
#19: Correcting filename [hash] string replacement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # modernizr-webpack-plugin
 
-Generate a custom modernizr build during webpack compile. 
+Generate a custom modernizr build during webpack compile.
 Includes support to integrate with [html-webpack-plugin](https://www.npmjs.com/package/html-webpack-plugin)
 
 [![npm version](https://badge.fury.io/js/modernizr-webpack-plugin.svg)](https://badge.fury.io/js/modernizr-webpack-plugin)
@@ -61,13 +61,13 @@ Additional options available via following config properties.
 ### filename
 Type: string
 
-Optional custom output filename. Support included for `[hash]` in output name.
+Optional custom output filename. Support included for `[hash]` and `[chunkhash]` in output name.
 Defaults to `modernizr-bundle.js`.
-*Note:* Will append `.js` extension if missing. 
+*Note:* Will append `.js` extension if missing.
 
 ```javascript
 var config = {
-  filename: 'my-bundle-name[hash].js',
+  filename: 'my-bundle-name[chunkhash].js',
 }
 ```
 
@@ -102,8 +102,8 @@ webpackConfig = {...
    plugins: [
      plugin,  
      new ModernizrWebpackPlugin({
-       // auto search through all webpack plugins for compatible 
-       // html-webpack-plugins and inject into all 
+       // auto search through all webpack plugins for compatible
+       // html-webpack-plugins and inject into all
        htmlWebpackPlugin: true
        // OR disable any html-webpack-plugin injection
        htmlWebpackPlugin: false
@@ -122,7 +122,7 @@ Type: boolean
 
 Option to simplify [html-webpack-plugin](https://www.npmjs.com/package/html-webpack-plugin) template reference
 Defaults to `false`.
- 
+
 ```javascript
 var htmlWebpackPluginConfig = {
   template:'template.html'

--- a/index.js
+++ b/index.js
@@ -114,9 +114,12 @@ ModernizrPlugin.prototype.apply = function (compiler) {
       var publicPath = self.resolvePublicPath(compilation, buildOptions.filename);
       var filename = buildOptions.filename;
       if (/\[hash\]/.test(buildOptions.filename)) {
-        self.oFilename = filename.replace(/\[hash\]/, self.createHash(output,
-          compiler.options.output.hashDigestLength));
+        self.oFilename = filename.replace(/\[hash\]/, compilation.hash);
         filename = filename.replace(/\[hash\]/, '');
+      } else if (/\[chunkhash\]/.test(buildOptions.filename)) {
+        self.oFilename = filename.replace(/\[chunkhash\]/, self.createHash(output,
+          compiler.options.output.hashDigestLength));
+        filename = filename.replace(/\[chunkhash\]/, '');
       } else {
         self.oFilename = filename;
       }

--- a/mocha.entry.js
+++ b/mocha.entry.js
@@ -44,6 +44,25 @@ describe('[ModernizrWebpackPlugin] Build Tests', function () {
       new ModernizrWebpackPlugin(config)
     ];
     webpack(webpackConfig).then(function (stats) {
+      var hashDigestLength = stats.compilation.hash;
+      return fs.readdirAsync(OUTPUT_PATH).then(function (files) {
+        var regexp = new RegExp('^testing' + hashDigestLength + '\\.js$');
+        files = files.filter(function (file) {
+          return regexp.test(file);
+        });
+        expect(files.length).to.equal(1);
+        done();
+      })
+    }).catch(done);
+  });
+
+  it('should output a chunkhashed filename', function (done) {
+    var config = {filename: 'testing[chunkhash]'};
+    webpackConfig.plugins = [
+      new HtmlWebpackPlugin(),
+      new ModernizrWebpackPlugin(config)
+    ];
+    webpack(webpackConfig).then(function (stats) {
       var hashDigestLength = stats.compilation.outputOptions.hashDigestLength;
       return fs.readdirAsync(OUTPUT_PATH).then(function (files) {
         var regexp = new RegExp('^testing[\\w\\d]{' + hashDigestLength + '}\\.js$');

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "object-assign": "^4.0.1",
     "uglify-js": "^2.4.24",
     "webpack-core": "^0.6.7",
-    "html-webpack-plugin": "^1.6.2 || ^2.0.4"
+    "html-webpack-plugin": "^1.6.2"
   },
   "devDependencies": {
     "bluebird": "^2.10.2",
@@ -49,6 +49,8 @@
     "karma-webpack": "^1.7.0",
     "mocha": "^2.3.3",
     "phantomjs": "^1.9.18",
+    "sinon": "^2.2.0",
+    "sinon-chai": "^2.10.0",
     "webpack": "^1.12.2"
   }
 }


### PR DESCRIPTION
This changes the current `[hash]` string replacement to be named `[chunkhash]`, and adds a proper `[hash]` string replacement for the webpack build hash.  See #19.