### PR TITLE
Use new webpack hooks syntax

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,7 +102,7 @@ ModernizrPlugin.prototype.validatePlugin = function (plugin) {
 ModernizrPlugin.prototype.apply = function (compiler) {
   var self = this;
 
-  compiler.plugin('after-compile', function (compilation, cb) {
+  (compiler.hooks ? compiler.hooks.afterCompile.tapAsync.bind(compiler.hooks.afterCompile, 'ModernizrWebpackPlugin') : compiler.plugin.bind(compiler, 'after-compile'))((compilation, cb) => {
 
     var buildOptions = assign({}, self.options);
 
@@ -158,7 +158,7 @@ ModernizrPlugin.prototype.apply = function (compiler) {
     })
   });
 
-  compiler.plugin('emit', function (compilation, cb) {
+  (compiler.hooks ? compiler.hooks.emit.tapAsync.bind(compiler.hooks.emit, 'ModernizrWebpackPlugin') : compiler.plugin.bind(compiler, 'emit'))((compilation, cb) => {
     var source = new ConcatSource();
 
     source.add(self.modernizrOutput);


### PR DESCRIPTION
Use the new Plugin syntax to avoid the `DeprecationWarning`:
```
DeprecationWarning: Tapable.plugin is deprecated. Use new API on `.hooks` instead
```
https://webpack.js.org/api/plugins/#plugin-types
https://webpack.js.org/api/compiler-hooks/